### PR TITLE
fix: disable linked-versions in release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,14 +1,6 @@
 {
     "plugins": [
-        "sentence-case",
-        {
-            "type": "linked-versions",
-            "group-name": "devenv",
-            "components": [
-                "devcontainer",
-                "container-latex"
-            ]
-        }
+        "sentence-case"
     ],
     "bump-minor-pre-major": true,
     "bump-patch-for-minor-pre-major": true,
@@ -32,18 +24,15 @@
     "packages": {
         ".": {
             "release-type": "simple",
-            "package-name": "jhatler",
-            "component": "jhatler"
+            "package-name": "jhatler"
         },
         ".devcontainer": {
             "release-type": "simple",
-            "package-name": "devcontainer",
-            "component": "devcontainer"
+            "package-name": "devcontainer"
         },
         "containers/latex": {
             "release-type": "simple",
             "package-name": "container-latex",
-            "component": "container-latex",
             "extra-files": [
                 ".devcontainer/Dockerfile"
             ]


### PR DESCRIPTION
This is a temporary fix to disable linked-versions in release-please
until the issue is resolved upstream or a better solution is found.

Refs: #27
Signed-off-by: Jaremy Hatler <hatler.jaremy@gmail.com>