### PR TITLE
chore: manually bump devcontainer base to 0.0.1

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,3 +1,3 @@
 # x-release-please-start-version
-FROM ghcr.io/jhatler/latex:v0.0.0
+FROM ghcr.io/jhatler/latex:v0.0.1
 # x-release-please-end


### PR DESCRIPTION
This was needed due to bugs in the current release-please workflow.

Refs: #30
Signed-off-by: Jaremy Hatler <hatler.jaremy@gmail.com>