### PR TITLE
fix: mark CHANGELOG files as generated

### DIFF
--- a/.devcontainer/CHANGELOG.md
+++ b/.devcontainer/CHANGELOG.md
@@ -9,3 +9,5 @@
 * Add devcontainer ([#11](https://github.com/jhatler/jhatler/issues/11)) ([816d7ca](https://github.com/jhatler/jhatler/commit/816d7caf6f7ad94aefee3429d56b42ccb256af52)), closes [#9](https://github.com/jhatler/jhatler/issues/9)
 * Cache (dev)container builds ([#22](https://github.com/jhatler/jhatler/issues/22)) ([5001444](https://github.com/jhatler/jhatler/commit/5001444df95c797da5baae722922c271c751ea7d)), closes [#19](https://github.com/jhatler/jhatler/issues/19)
 * Use full texlive scheme in devcontainer ([#18](https://github.com/jhatler/jhatler/issues/18)) ([3d129c8](https://github.com/jhatler/jhatler/commit/3d129c8d6cd01ad6dd9118fe4c44d69a9326eef4)), closes [#15](https://github.com/jhatler/jhatler/issues/15)
+
+<!--- @generated --->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,3 +20,5 @@
 
 * Disable linked-versions in release-please ([#28](https://github.com/jhatler/jhatler/issues/28)) ([4d8888b](https://github.com/jhatler/jhatler/commit/4d8888b0f1add6e5ff6d6582d7954892063aae31)), closes [#27](https://github.com/jhatler/jhatler/issues/27)
 * Disable node-workspace in release-please ([#26](https://github.com/jhatler/jhatler/issues/26)) ([b1bac0f](https://github.com/jhatler/jhatler/commit/b1bac0fb33209054973016a6e2e96ee77b03d6be)), closes [#25](https://github.com/jhatler/jhatler/issues/25)
+
+<!--- @generated --->

--- a/containers/latex/CHANGELOG.md
+++ b/containers/latex/CHANGELOG.md
@@ -6,3 +6,5 @@
 ### Features
 
 * Cache (dev)container builds ([#22](https://github.com/jhatler/jhatler/issues/22)) ([5001444](https://github.com/jhatler/jhatler/commit/5001444df95c797da5baae722922c271c751ea7d)), closes [#19](https://github.com/jhatler/jhatler/issues/19)
+
+<!--- @generated --->


### PR DESCRIPTION
This is needed to have super-linter ignore their contents. The natural
language linter is currently failing on them.

Refs: #33
Signed-off-by: Jaremy Hatler <hatler.jaremy@gmail.com>