### PR TITLE
fix: ignore CHANGELOGs in PRs and container builds

### DIFF
--- a/.devcontainer/.dockerignore
+++ b/.devcontainer/.dockerignore
@@ -1,0 +1,4 @@
+local-features
+CHANGELOG.md
+devcontainer.json
+postCreateCommand.sh

--- a/.github/workflows/pr-devcontainer.yml
+++ b/.github/workflows/pr-devcontainer.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - '.devcontainer/**'
+      - '!.devcontainer/CHANGELOG.md'
 
 concurrency:
   # For pull requests, cancel all currently-running jobs for this workflow

--- a/.github/workflows/pr-latex-container.yml
+++ b/.github/workflows/pr-latex-container.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'containers/latex/**'
+      - '!containers/latex/CHANGELOG.md'
 
 concurrency:
   # For pull requests, cancel all currently-running jobs for this workflow

--- a/containers/latex/.dockerignore
+++ b/containers/latex/.dockerignore
@@ -1,0 +1,1 @@
+CHANGELOG.md


### PR DESCRIPTION
This adds an exclusion to the pr-devcontainer and pr-latex-container
workflows to ignore changes to the CHANGELOGs. This is to prevent
unnecessary rebuilds of the containers, slowing the PR process.

.dockerignore files were also added to the devcontainer and latex base
containers to prevent the CHANGELOGs from being copied into the build
context. The devcontainer .dockerignore file was also updated to ignore
the devcontainer-specific files.

Refs: #35
Signed-off-by: Jaremy Hatler <hatler.jaremy@gmail.com>