### PR TITLE
revert: enable linked-versions in release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,14 @@
 {
     "plugins": [
-        "sentence-case"
+        "sentence-case",
+        {
+            "type": "linked-versions",
+            "group-name": "devenv",
+            "components": [
+                "devcontainer",
+                "container-latex"
+            ]
+        }
     ],
     "bump-minor-pre-major": true,
     "bump-patch-for-minor-pre-major": true,
@@ -24,15 +32,18 @@
     "packages": {
         ".": {
             "release-type": "simple",
-            "package-name": "jhatler"
+            "package-name": "jhatler",
+            "component": "jhatler"
         },
         ".devcontainer": {
             "release-type": "simple",
-            "package-name": "devcontainer"
+            "package-name": "devcontainer",
+            "component": "devcontainer"
         },
         "containers/latex": {
             "release-type": "simple",
             "package-name": "container-latex",
+            "component": "container-latex",
             "extra-files": [
                 ".devcontainer/Dockerfile"
             ]


### PR DESCRIPTION
This reverts commit 4d8888b0f1add6e5ff6d6582d7954892063aae31 (#28). This
was a temporary change to get release-please bootstrapped. The linked
versions plugin needs to be used to ensure that the extra-files config
works as expected.

Refs: #30, #27
Signed-off-by: Jaremy Hatler <hatler.jaremy@gmail.com>