### PR TITLE
fix: disable linked-versions internal merge

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,8 @@
             "components": [
                 "devcontainer",
                 "container-latex"
-            ]
+            ],
+            "merge": false
         }
     ],
     "bump-minor-pre-major": true,


### PR DESCRIPTION
Disabling the internal merge for linked-versions should resolve the
issue where the release-please workflow fails due to an undefined
group branch name.

Refs: #39
Signed-off-by: Jaremy Hatler <hatler.jaremy@gmail.com>