### PR TITLE
fix: move extra-files to .devcontainer component

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -39,15 +39,15 @@
         ".devcontainer": {
             "release-type": "simple",
             "package-name": "devcontainer",
-            "component": "devcontainer"
+            "component": "devcontainer",
+            "extra-files": [
+                "Dockerfile"
+            ]
         },
         "containers/latex": {
             "release-type": "simple",
             "package-name": "container-latex",
-            "component": "container-latex",
-            "extra-files": [
-                ".devcontainer/Dockerfile"
-            ]
+            "component": "container-latex"
         }
     }
 }


### PR DESCRIPTION
This moves the extra-files configuration in release-please to the
.devcontainer component. This was done because the extra-files config
can only update files under the package path.

Refs: #30
Signed-off-by: Jaremy Hatler <hatler.jaremy@gmail.com>