### PR TITLE
fix: use devcontainer cli directly

### DIFF
--- a/.github/workflows/pr-devcontainer.yml
+++ b/.github/workflows/pr-devcontainer.yml
@@ -22,13 +22,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set short git commit SHA
-        id: git
-        shell: bash
-        run: echo "short_sha=$(git rev-parse --short ${{ github.sha }})" >> "$GITHUB_OUTPUT"
-
       - name: Build Devcontainer
-        uses: devcontainers/ci@v0.3
-        with:
-          cacheFrom: ghcr.io/jhatler/jhatler-devcontainer
-          push: never
+        shell: bash
+        run: |
+          devcontainer build \
+            --workspace-folder ${{ github.workspace }} \
+            --cache-from ghcr.io/jhatler/jhatler-devcontainer

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -55,11 +55,12 @@ jobs:
 
       - name: Publish Devcontainer
         if: ${{ steps.release.outputs['.devcontainer--release_created'] || steps.release.outputs['containers/latex--release_created'] }}
-        uses: devcontainers/ci@v0.3.1900000338
-        env:
-          BUILDX_NO_DEFAULT_ATTESTATIONS: true
-        with:
-          imageName: ghcr.io/jhatler/jhatler-devcontainer
-          imageTag: ${{ steps.git.outputs.short_sha }},v${{ steps.release.outputs['.devcontainer--major'] }}.${{ steps.release.outputs['.devcontainer--minor'] }}.${{ steps.release.outputs['.devcontainer--patch'] }}
-          cacheFrom: ghcr.io/jhatler/jhatler-devcontainer
-          push: always
+        shell: bash
+        run: |
+          devcontainer build \
+            --workspace-folder ${{ github.workspace }} \
+            --cache-from ghcr.io/jhatler/jhatler-devcontainer \
+            --image-name ghcr.io/jhatler/jhatler-devcontainer:latest \
+            --image-name ghcr.io/jhatler/jhatler-devcontainer:${{ steps.git.outputs.short_sha }} \
+            --image-name ghcr.io/jhatler/jhatler-devcontainer:v${{ steps.release.outputs['.devcontainer--major'] }}.${{ steps.release.outputs['.devcontainer--minor'] }}.${{ steps.release.outputs['.devcontainer--patch'] }} \
+            --push


### PR DESCRIPTION
The devcontainer ci action has been unreliable. This updates the
release-please and pr-devcontainer workflows to use the CLI directly
instead of the action. If this doesn't resolve the build failures it
will at least make it easier to debug.

Refs: #31
Signed-off-by: Jaremy Hatler <hatler.jaremy@gmail.com>