### PR TITLE
fix: use string compare for booleans in actions

### DIFF
--- a/.github/actions/container/action.yml
+++ b/.github/actions/container/action.yml
@@ -60,7 +60,7 @@ runs:
       run: echo "short_sha=$(git rev-parse --short ${{ github.sha }})" >> "$GITHUB_OUTPUT"
 
     - name: Build container
-      if: ${{ !inputs.push }}
+      if: ${{ inputs.push == 'false' }}
       uses: docker/build-push-action@v5
       env:
         DOCKER_BUILDKIT: 1
@@ -76,7 +76,7 @@ runs:
           ${{ inputs.repository }}:${{ steps.git.outputs.short_sha }}
 
     - name: Build and Push container
-      if: ${{ inputs.push }}
+      if: ${{ inputs.push == 'true' }}
       uses: docker/build-push-action@v5
       env:
         DOCKER_BUILDKIT: 1

--- a/.github/actions/devcontainer/action.yml
+++ b/.github/actions/devcontainer/action.yml
@@ -70,7 +70,7 @@ runs:
       run: echo "short_sha=$(git rev-parse --short ${{ github.sha }})" >> "$GITHUB_OUTPUT"
 
     - name: Build devcontainer
-      if: ${{ !inputs.push }}
+      if: ${{ inputs.push == 'false' }}
       shell: bash
       run: |
         devcontainer build \
@@ -81,7 +81,7 @@ runs:
           --image-name ${{ inputs.repository }}:${{ steps.git.outputs.short_sha }}
 
     - name: Build and Push devcontainer
-      if: ${{ inputs.push }}
+      if: ${{ inputs.push == 'true' }}
       shell: bash
       run: |
         devcontainer build \


### PR DESCRIPTION
This fixes the issue where the action conditionals were not working
properly. GitHub Actions does not use proper conditionals.

Refs: #58
Signed-off-by: Jaremy Hatler <hatler.jaremy@gmail.com>