### PR TITLE
fix: downgrade docker-related actions

### DIFF
--- a/.github/actions/container/action.yml
+++ b/.github/actions/container/action.yml
@@ -42,13 +42,13 @@ runs:
   using: "composite"
   steps:
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@v2.2.0
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v2.7.0
 
     - name: Login to Container Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@v2.2.0
       with:
         registry: ${{ inputs.registry }}
         username: ${{ inputs.username }}

--- a/.github/actions/devcontainer/action.yml
+++ b/.github/actions/devcontainer/action.yml
@@ -43,10 +43,10 @@ runs:
   using: "composite"
   steps:
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@v2.2.0
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v2.7.0
 
     - name: Set up Node
       uses: actions/setup-node@v4
@@ -58,7 +58,7 @@ runs:
       run: npm install -g @devcontainers/cli@0.54.2
 
     - name: Login to Container Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@v2.2.0
       with:
         registry: ${{ inputs.registry }}
         username: ${{ inputs.username }}


### PR DESCRIPTION
The following actions were downgraded.
- docker/login-action to v2.2.0
- docker/setup-qemu-action to v2.2.0
- docker/setup-buildx-action to v2.7.0

Refs: #63
Signed-off-by: Jaremy Hatler <hatler.jaremy@gmail.com>