### PR TITLE
fix: qualify path for release versioning

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -55,7 +55,7 @@
             "package-name": "devcontainer-latex",
             "component": "devcontainer-latex",
             "extra-files": [
-                "devcontainer.json"
+                ".devcontainer/devcontainer.json"
             ]
         }
     }


### PR DESCRIPTION
The release-please extra-files config did not have the qualified path
for the devcontainers/latex package.

Refs: #67
Signed-off-by: Jaremy Hatler <hatler.jaremy@gmail.com>