### PR TITLE
feat: add JSON schemas for devcontainer files

### DIFF
--- a/devcontainers/latex/.devcontainer/devcontainer.json
+++ b/devcontainers/latex/.devcontainer/devcontainer.json
@@ -52,6 +52,21 @@
                 "files.associations": {
                     "*.tex": "latex"
                 },
+                "json.schemas": [
+                    {
+                        "fileMatch": [
+                            "*/devcontainer-feature.json"
+                        ],
+                        "url": "https://raw.githubusercontent.com/devcontainers/spec/main/schemas/devContainerFeature.schema.json"
+                    },
+                    {
+                        "fileMatch": [
+                            "*/devcontainer.json",
+                            "*/.devcontainer.json"
+                        ],
+                        "url": "https://raw.githubusercontent.com/devcontainers/spec/main/schemas/devContainer.schema.json"
+                    }
+                ],
                 "latex-workshop.latexindent.path": "latexindent",
                 "latex-workshop.latexindent.args": [
                     "-c",

--- a/devcontainers/latex/.devcontainer/local-features/devcontainers/devcontainer-feature.json
+++ b/devcontainers/latex/.devcontainer/local-features/devcontainers/devcontainer-feature.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://raw.githubusercontent.com/devcontainers/spec/main/schemas/devContainerFeature.schema.json",
     "id": "devcontainers",
     "name": "devcontainers",
 	"installsAfter": [

--- a/devcontainers/latex/.devcontainer/local-features/liquidprompt/devcontainer-feature.json
+++ b/devcontainers/latex/.devcontainer/local-features/liquidprompt/devcontainer-feature.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://raw.githubusercontent.com/devcontainers/spec/main/schemas/devContainerFeature.schema.json",
     "id": "liquidprompt",
     "name": "liquidprompt"
 }

--- a/devcontainers/latex/.devcontainer/local-features/release-please/devcontainer-feature.json
+++ b/devcontainers/latex/.devcontainer/local-features/release-please/devcontainer-feature.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://raw.githubusercontent.com/devcontainers/spec/main/schemas/devContainerFeature.schema.json",
     "id": "release-please",
     "name": "release-please",
 	"installsAfter": [

--- a/devcontainers/latex/.devcontainer/local-features/shfmt/devcontainer-feature.json
+++ b/devcontainers/latex/.devcontainer/local-features/shfmt/devcontainer-feature.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://raw.githubusercontent.com/devcontainers/spec/main/schemas/devContainerFeature.schema.json",
     "id": "shfmt",
     "name": "shfmt",
 	"installsAfter": [


### PR DESCRIPTION
This adds the $schema property to the devcontainer.json and
devcontainer-feature.json files. It also configures the latex container
to associate those file names with the schemas.

Refs: #61
Signed-off-by: Jaremy Hatler <hatler.jaremy@gmail.com>