### PR TITLE
fix: mark .devcontainer CHANGELOG as autogenerated

### DIFF
--- a/.devcontainer/CHANGELOG.md
+++ b/.devcontainer/CHANGELOG.md
@@ -22,3 +22,5 @@ This release failed to deploy.
 ### Features
 
 * Devcontainer publishing ([#57](https://github.com/jhatler/jhatler/issues/57)) ([4b91e5f](https://github.com/jhatler/jhatler/commit/4b91e5f4a62fe5053b7cdd0c7ba54258c65513e4)), closes [#46](https://github.com/jhatler/jhatler/issues/46)
+
+<!--- @generated --->


### PR DESCRIPTION
This is needed for the super-linter checks to pass.

Refs: #93
Signed-off-by: Jaremy Hatler <hatler.jaremy@gmail.com>