### PR TITLE
fix: update LICENSE for actual project owner

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Kori Ryter
+Copyright (c) 2023 Jaremy Hatler
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Kori Ryter (@kryter) was accidentally listed as the copyright holder for
this project. This commit fixes that by updating the LICENSE file to
specify that Jaremy Hatler (@jhatler) is the copyright holder.

Refs: #99
Signed-off-by: Jaremy Hatler <hatler.jaremy@gmail.com>