### PR TITLE
chore: include .vscode in eslint config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,7 +3,8 @@
     "ignorePatterns": [
         "!.eslintrc.json",
         "!.release-please-manifest.json",
-        "!.devcontainer"
+        "!.devcontainer",
+        "!.vscode"
     ],
     "overrides": [
         {


### PR DESCRIPTION
Dot directories are ignored by default in eslint. This commit adds
.vscode to the list of directories to be linted.

Refs: #104
Signed-off-by: Jaremy Hatler <hatler.jaremy@gmail.com>