### PR TITLE
fix: cleanup container tars after load

### DIFF
--- a/.github/actions/container/action.yml
+++ b/.github/actions/container/action.yml
@@ -83,6 +83,7 @@ runs:
       shell: bash
       run: |
         docker load -i ${{ github.workspace }}/${{ steps.uuid.outputs.uuid }}.tar
+        rm -f ${{ github.workspace }}/${{ steps.uuid.outputs.uuid }}.tar
 
     - name: Tag container
       if: ${{ inputs.push == 'true' }}

--- a/.github/actions/devcontainer/action.yml
+++ b/.github/actions/devcontainer/action.yml
@@ -94,6 +94,8 @@ runs:
       shell: bash
       run: |
         docker load -i ${{ github.workspace }}/${{ steps.uuid.outputs.uuid }}.tar
+        rm -f ${{ github.workspace }}/${{ steps.uuid.outputs.uuid }}.tar
+        rm -f ${{ github.workspace }}/${{ steps.uuid.outputs.uuid }}.stdout
 
     - name: Tag devcontainer
       if: ${{ inputs.push == 'true' }}


### PR DESCRIPTION
This reduces the disk usage of the container and devcontainer actions
by removing the tar files after they are loaded into docker.

Refs: #107
Signed-off-by: Jaremy Hatler <hatler.jaremy@gmail.com>