### PR TITLE
feat: add cleanup to (dev)container actions

### DIFF
--- a/.github/actions/container/action.yml
+++ b/.github/actions/container/action.yml
@@ -37,6 +37,10 @@ inputs:
   password:
     description: 'OCI Registry Password'
     required: true
+  cleanup:
+    description: 'Cleanup images after build?'
+    required: true
+    default: true
 
 runs:
   using: "composite"
@@ -104,3 +108,16 @@ runs:
         docker push ${{ inputs.repository }}:v${{ inputs.semver_major }}.${{ inputs.semver_minor }}.${{ inputs.semver_patch }}
         docker push ${{ inputs.repository }}:v${{ inputs.semver_major }}.${{ inputs.semver_minor }}
         docker push ${{ inputs.repository }}:v${{ inputs.semver_major }}
+
+    - name: Cleanup container build
+      if: ${{ inputs.cleanup == 'true' }}
+      shell: bash
+      run: |
+        docker image rm -f ${{ steps.build.outputs.imageid }} \
+          ${{ inputs.repository }}:latest \
+          ${{ inputs.repository }}:${{ steps.git.outputs.short_sha }} \
+          ${{ inputs.repository }}:v${{ inputs.semver_major }}.${{ inputs.semver_minor }}.${{ inputs.semver_patch }} \
+          ${{ inputs.repository }}:v${{ inputs.semver_major }}.${{ inputs.semver_minor }} \
+          ${{ inputs.repository }}:v${{ inputs.semver_major }}
+
+        docker builder prune --all --force --verbose

--- a/.github/actions/devcontainer/action.yml
+++ b/.github/actions/devcontainer/action.yml
@@ -38,6 +38,10 @@ inputs:
   password:
     description: 'OCI Registry Password'
     required: true
+  cleanup:
+    description: 'Cleanup images after build?'
+    required: true
+    default: true
 
 runs:
   using: "composite"
@@ -116,3 +120,16 @@ runs:
         docker push ${{ inputs.repository }}:v${{ inputs.semver_major }}.${{ inputs.semver_minor }}.${{ inputs.semver_patch }}
         docker push ${{ inputs.repository }}:v${{ inputs.semver_major }}.${{ inputs.semver_minor }}
         docker push ${{ inputs.repository }}:v${{ inputs.semver_major }}
+
+    - name: Cleanup devcontainer build
+      if: ${{ inputs.cleanup == 'true' }}
+      shell: bash
+      run: |
+        docker image rm -f ${{ steps.build.outputs.image_name }} \
+          ${{ inputs.repository }}:latest \
+          ${{ inputs.repository }}:${{ steps.git.outputs.short_sha }} \
+          ${{ inputs.repository }}:v${{ inputs.semver_major }}.${{ inputs.semver_minor }}.${{ inputs.semver_patch }} \
+          ${{ inputs.repository }}:v${{ inputs.semver_major }}.${{ inputs.semver_minor }} \
+          ${{ inputs.repository }}:v${{ inputs.semver_major }}
+
+        docker builder prune --all --force --verbose


### PR DESCRIPTION
This adds input parameters to the (dev)container actions to allow
for cleanup of the workspace disk. The cleanup is done by removing
the built images and also pruning the build cache.

Refs: #107
Signed-off-by: Jaremy Hatler <hatler.jaremy@gmail.com>