### PR TITLE
fix: use medium texlive scheme to save space

### DIFF
--- a/containers/latex/texlive-profile.txt
+++ b/containers/latex/texlive-profile.txt
@@ -1,4 +1,4 @@
-selected_scheme scheme-full
+selected_scheme scheme-medium
 instopt_letter 1
 tlpdbopt_autobackup 0
 tlpdbopt_desktop_integration 0


### PR DESCRIPTION
Builds on GitHub Actions were failing due to the large size of the
full texlive scheme. This commit changes the scheme to medium to
reduce the size of the image.

Refs: #107
Signed-off-by: Jaremy Hatler <hatler.jaremy@gmail.com>