### PR TITLE
docs: document deploy failures

### DIFF
--- a/.devcontainer/CHANGELOG.md
+++ b/.devcontainer/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [0.0.8](https://github.com/jhatler/jhatler/compare/devcontainer-v0.0.7...devcontainer-v0.0.8) (2023-12-09)
 
+This release failed to deploy.
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [0.0.8](https://github.com/jhatler/jhatler/compare/jhatler-v0.0.7...jhatler-v0.0.8) (2023-12-09)
 
+This release failed to deploy.
 
 ### Features
 

--- a/containers/latex/CHANGELOG.md
+++ b/containers/latex/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [0.0.8](https://github.com/jhatler/jhatler/compare/container-latex-v0.0.7...container-latex-v0.0.8) (2023-12-09)
 
+This release failed to deploy.
 
 ### Documentation
 

--- a/devcontainers/latex/CHANGELOG.md
+++ b/devcontainers/latex/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [0.0.8](https://github.com/jhatler/jhatler/compare/devcontainer-latex-v0.0.7...devcontainer-latex-v0.0.8) (2023-12-09)
 
+This release failed to deploy.
 
 ### Documentation
 


### PR DESCRIPTION
This documents that the 0.0.08 release failed to deploy in all the
CHANGELOG.md files.

Refs: #108
Signed-off-by: Jaremy Hatler <hatler.jaremy@gmail.com>