### PR TITLE
feat: add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/containers/latex/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "devcontainers"
+    directory: "/devcontainers/latex/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This adds a dependabot config covering the containers, devcontainers, and NodeJS environments within this repo.

Fixes: #118
Signed-off-by: Jaremy Hatler <root@jhatler.com>
