### PR TITLE
fix: add github-actions support to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This should have been done in the original integration, but was missed.

Fixes: #126
Refs: #118
Signed-off-by: Jaremy Hatler <root@jhatler.com>
