### PR TITLE
feat: use f516z33 runner for workflows

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -1,4 +1,5 @@
 ---
 self-hosted-runner:
-  labels: []
+  labels:
+    - f516z33
 config-variables: []

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,7 +13,9 @@ permissions:
 
 jobs:
   release-please:
-    runs-on: ubuntu-latest
+    runs-on:
+      - self-hosted
+      - f516z33
     environment: main
     steps:
       - name: Process Release


### PR DESCRIPTION
This updates the GitHub Actions workflows (except codeql) to use the
self-hosted f516z33 runner. This is my personal workstartion where my
YubiKey is accessible.

Fixes: #133
Signed-off-by: Jaremy Hatler <root@jhatler.com>