### PR TITLE
fix: update release-please location

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,10 +19,8 @@ jobs:
     environment: main
     steps:
       - name: Process Release
-        uses: google-github-actions/release-please-action@v4
+        uses: googleapis/release-please-action@v4
         id: release
-        with:
-          command: manifest
 
       - name: Checkout
         if: ${{ steps.release.outputs.releases_created }}


### PR DESCRIPTION
It has moved to googleapis/release-please-action.
This also removed the command parameter, which is no longer supported.

Fixes: #139
Signed-off-by: Jaremy Hatler <root@jhatler.com>