### PR TITLE
chore: update node to version 22

### DIFF
--- a/.github/actions/devcontainer/action.yml
+++ b/.github/actions/devcontainer/action.yml
@@ -55,7 +55,7 @@ runs:
     - name: Set up Node
       uses: actions/setup-node@v4
       with:
-        node-version: 20
+        node-version: 22
 
     - name: Install Devcontainer CLI
       shell: bash

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: "npm"
 
       - name: Cache NPM dependencies

--- a/devcontainers/latex/.devcontainer/devcontainer.json
+++ b/devcontainers/latex/.devcontainer/devcontainer.json
@@ -15,7 +15,7 @@
       "version": "latest"
     },
     "ghcr.io/devcontainers/features/node:1": {
-      "version": "20"
+      "version": "22"
     },
     "ghcr.io/devcontainers/features/go:1": {
       "version": "latest"


### PR DESCRIPTION
This is the latest LTS and is only used for linting.

Fixes: #141
Signed-off-by: Jaremy Hatler <root@jhatler.com>