### PR TITLE
feat: add muratcankaracabey/latex_cv as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "latex/modules/muratcankaracabey"]
+	path = latex/modules/muratcankaracabey
+	url = https://github.com/muratcankaracabey/latex_cv/

--- a/latex/class/muratcan_cv.cls
+++ b/latex/class/muratcan_cv.cls
@@ -1,0 +1,1 @@
+../modules/muratcankaracabey/muratcan_cv.cls


### PR DESCRIPTION
This adds the muratcan_cv LaTeX class from muratcankaracabey as a
submodule.

It also adds a symlink to the class file for convenience.

Fixes: #150
Origin: muratcankaracabey
URL: https://github.com/muratcankaracabey/latex_cv
commit: 970e310a110004a47bda4c0ebd179384e94f3011
Purpose: use of LaTeX class in resume/CV
Signed-off-by: Jaremy Hatler <root@jhatler.com>