### PR TITLE
chore: mostly ignore .gitmodules in editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -22,6 +22,11 @@ max_line_length = 72
 [TAG_EDITMSG]
 max_line_length = 72
 
+# Git submodule config
+[.gitmodules]
+max_line_length = unset
+indent_style = tab
+
 # Markdown files
 [*.md]
 max_line_length = unset


### PR DESCRIPTION
Only basic checking relevant to the file type is done (encode, newline,
etc.).

Fixes: #153
Signed-off-by: Jaremy Hatler <root@jhatler.com>