### PR TITLE
fix: move LaTeX class symlinks up a level

### DIFF
--- a/latex/awesome-cv.cls
+++ b/latex/awesome-cv.cls
@@ -1,0 +1,1 @@
+modules/posquit0/awesome-cv.cls

--- a/latex/class/awesome-cv.cls
+++ b/latex/class/awesome-cv.cls
@@ -1,1 +1,0 @@
-../modules/posquit0/awesome-cv.cls

--- a/latex/class/muratcan_cv.cls
+++ b/latex/class/muratcan_cv.cls
@@ -1,1 +1,0 @@
-../modules/muratcankaracabey/muratcan_cv.cls

--- a/latex/muratcan_cv.cls
+++ b/latex/muratcan_cv.cls
@@ -1,0 +1,1 @@
+modules/muratcankaracabey/muratcan_cv.cls


### PR DESCRIPTION
This simplifies using their usage.

Fixes: #158
Signed-off-by: Jaremy Hatler <root@jhatler.com>