### PR TITLE
feat: add support for resume and CV links

### DIFF
--- a/latex/awesome-cv.cls
+++ b/latex/awesome-cv.cls
@@ -284,6 +284,14 @@
 % Usage: \homepage{<url>}
 \newcommand*{\homepage}[1]{\def\@homepage{#1}}
 
+% Defines writer's CV link (optional)
+% Usage: \cv{<url>}
+\newcommand*{\cv}[1]{\def\@cv{#1}}
+
+% Defines writer's Resume link (optional)
+% Usage: \resume{<url>}
+\newcommand*{\resume}[1]{\def\@resume{#1}}
+
 % Defines writer's github (optional)
 % Usage: \github{<github-nick>}
 \newcommand*{\github}[1]{\def\@github{#1}}
@@ -505,13 +513,25 @@
         {}%
         {%
           \ifbool{isstart}{\setbool{isstart}{false}}{\acvHeaderSocialSep}%
-          \href{http://\@homepage}{\faHome\acvHeaderIconSep\@homepage}%
+          \href{https://\@homepage}{\faHome\acvHeaderIconSep\@homepage}%
         }%
       \ifthenelse{\isundefined{\@github}}%
         {}%
         {%
           \ifbool{isstart}{\setbool{isstart}{false}}{\acvHeaderSocialSep}%
           \href{https://github.com/\@github}{\faGithubSquare\acvHeaderIconSep\@github}%
+        }%
+        \ifthenelse{\isundefined{\@resume}}%
+          {}%
+          {%
+            \ifbool{isstart}{\setbool{isstart}{false}}{\acvHeaderSocialSep}%
+            \href{https://\@resume}{\faCheckCircle\acvHeaderIconSep\@resume}%
+          }%
+        \ifthenelse{\isundefined{\@cv}}%
+        {}%
+        {%
+          \ifbool{isstart}{\setbool{isstart}{false}}{\acvHeaderSocialSep}%
+          \href{https://\@cv}{\faPlusCircle\acvHeaderIconSep\@cv}%
         }%
       \ifthenelse{\isundefined{\@gitlab}}%
         {}%

--- a/latex/patches/0002-add-resume-cv-links.patch
+++ b/latex/patches/0002-add-resume-cv-links.patch
@@ -1,0 +1,46 @@
+diff '--color=auto' -ru a/awesome-cv.cls b/awesome-cv.cls
+--- a/awesome-cv.cls	2025-03-02 19:01:55.071479052 -0500
++++ b/awesome-cv.cls	2025-03-02 19:21:49.857106896 -0500
+@@ -284,6 +284,14 @@
+ % Usage: \homepage{<url>}
+ \newcommand*{\homepage}[1]{\def\@homepage{#1}}
+ 
++% Defines writer's CV link (optional)
++% Usage: \cv{<url>}
++\newcommand*{\cv}[1]{\def\@cv{#1}}
++
++% Defines writer's Resume link (optional)
++% Usage: \resume{<url>}
++\newcommand*{\resume}[1]{\def\@resume{#1}}
++
+ % Defines writer's github (optional)
+ % Usage: \github{<github-nick>}
+ \newcommand*{\github}[1]{\def\@github{#1}}
+@@ -505,7 +513,7 @@
+         {}%
+         {%
+           \ifbool{isstart}{\setbool{isstart}{false}}{\acvHeaderSocialSep}%
+-          \href{http://\@homepage}{\faHome\acvHeaderIconSep\@homepage}%
++          \href{https://\@homepage}{\faHome\acvHeaderIconSep\@homepage}%
+         }%
+       \ifthenelse{\isundefined{\@github}}%
+         {}%
+@@ -513,6 +521,18 @@
+           \ifbool{isstart}{\setbool{isstart}{false}}{\acvHeaderSocialSep}%
+           \href{https://github.com/\@github}{\faGithubSquare\acvHeaderIconSep\@github}%
+         }%
++        \ifthenelse{\isundefined{\@resume}}%
++          {}%
++          {%
++            \ifbool{isstart}{\setbool{isstart}{false}}{\acvHeaderSocialSep}%
++            \href{https://\@resume}{\faCheckCircle\acvHeaderIconSep\@resume}%
++          }%
++        \ifthenelse{\isundefined{\@cv}}%
++        {}%
++        {%
++          \ifbool{isstart}{\setbool{isstart}{false}}{\acvHeaderSocialSep}%
++          \href{https://\@cv}{\faPlusCircle\acvHeaderIconSep\@cv}%
++        }%
+       \ifthenelse{\isundefined{\@gitlab}}%
+         {}%
+         {%


### PR DESCRIPTION
These commands were adapted from the \homepage command which was already
present in the class.

Fixes: #162
Signed-off-by: Jaremy Hatler <root@jhatler.com>