### PR TITLE
chore: slim down super-linter

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,5 +3,5 @@
   "image": "ghcr.io/jhatler/latex-devcontainer:v0.0.12" /* x-release-please-version */,
   "remoteUser": "vscode",
   "containerUser": "vscode",
-  "postCreateCommand": "docker pull ghcr.io/super-linter/super-linter:v7.3.0"
+  "postCreateCommand": "docker pull ghcr.io/super-linter/super-linter:slim-v7.3.0"
 }

--- a/scripts/lint
+++ b/scripts/lint
@@ -33,7 +33,7 @@ function run_linter() {
         -e RUN_LOCAL=true \
         -e USE_FIND_ALGORITHM=true \
         --env-file "$_WORKSPACE"/.github/super-linter.env \
-        -v "$_WORKSPACE":/tmp/lint ghcr.io/super-linter/super-linter:v7.3.0
+        -v "$_WORKSPACE":/tmp/lint ghcr.io/super-linter/super-linter:slim-v7.3.0
 }
 
 # Parse arguments


### PR DESCRIPTION
This updates the devcontainer and lint script to use the slim version of
super-linter. This should accelerate the linter runs.

Fixes: #170
Signed-off-by: Jaremy Hatler <root@jhatler.com>