### PR TITLE
feat: add links to README for Resumes/CV/Project

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,58 @@
 
 # Hey there, I'm Jaremy! This is where I write code and prosper. 🖖
 
+I'm a DevOps practitioner and student of technology in all its forms. There are few things I enjoy more than learning
+and exploring new systems to see what lessons I can glean to share with others. Over the years, I've learned
+that transforming and adapting complex systems isn't just about code or technology — it's about inspiring your fellow
+humans to go on a journey of learning together, to feel excited about making everyone's day go a little smoother.
+
+Here, I share my journey, my experiments with code, and the occasional insight on how a small tweak can make a big
+difference. I hope you find something useful, or at least entertaining, in my work. Feel free to reach out!
+
+## Cryptography
+
+Because of my work in security and the amount of access I generally have to sensitive data, I take my personal
+operational security very seriously. Below you'll find a link to my trust chain containing my PGP, SMIME, and other
+public keys. I've also included a link to my Keybase profile, which is a great way to verify my identity and
+pull my keys from a trusted source.
+
+Unless otherwise noted or discussed, if you receive a communication from me that isn't signed in some way you should
+consider it to be untrusted and reach out to me directly to verify its authenticity.
+
+- Trust Chain: [jhatler/trust-chain](https://github.com/jhatler/trust-chain)
 - Keybase: [jaremyhatler](https://keybase.io/jaremyhatler)
+
+## Projects
+
+- **[JANUS](https://github.com/jhatler/janus):** Internal Development Platform (IDP) targeting complex multi‑cloud environments like AI/ML workloads, IoT Device Management, OS distribution
+  and support, etc.
+  - Core Tech:
+    - Spacelift
+    - Ansible
+    - Terraform
+    - Packer
+    - Docker
+    - Devcontainers
+    - GitHub Actions/Codespaces
+    - Aikido
+    - Codacy
+    - Infracost
+  - Supports Ubuntu 8.04.4 and up to aid in migration of legacy systems to modern platforms.
+- In my pins, you'll find various repos related to my Gentoo use, including a few overlays.
+  These are unpolished at the moment, but I'm in the process of incorporating a large amount
+  of out-of-band work I've done to produce a full-fledged, security-focused Linux distribution.
+  It's my daily driver but hic sunt dracones until I get the infrastructure in place to support
+  others. Stay tuned for more updates on that!
+
+## Resumes and CVs
+
+If you're interested in my work history, you can find my resumes and CVs below. They're LaTeX based, rendered
+to PDFs dynamically based on the data in this repository. The resumes are targeted towards specific roles and are a
+subset of the information my CV, which is a comprehensive overview of my experiences and skills.
+
+- [CV](https://cv.jhatler.com/)
+- [Resume - DevOps Engineer](https://resume.jhatler.com/devops)
+- [Resume - Platform Engineer](https://resume.jhatler.com/platform)
+- [Resume - Site Reliability Engineer](https://resume.jhatler.com/sre)
+- [Resume - Security Engineer](https://resume.jhatler.com/security)
+- [Resume - Solutions Architect](https://resume.jhatler.com/architect)


### PR DESCRIPTION
This updates the readme to include links to the resumes and CVs, in
addition to an introduction to myself and some of my projects.

Fixes: #14
Signed-off-by: Jaremy Hatler <root@jhatler.com>